### PR TITLE
fix: change broken ubuntu mirror url

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -3,6 +3,7 @@ name: pull-requests
 on:
   pull_request:
     branches:
+      - development
       - RC
       - master
 

--- a/roles/netbootxyz/templates/disks/netboot.xyz.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz.j2
@@ -3,7 +3,7 @@
 # =============================================================================
 # Ubuntu Installer Configuration
 # =============================================================================
-set mirror https://releases.ubuntu.com
+set mirror https://old-releases.ubuntu.com/releases/
 set base_dir ubuntu
 set codename noble
 set version 24.04.2
@@ -14,8 +14,8 @@ set ubuntu_message Starting Ubuntu ${version} installer...
 set ramdisk_size 3500000
 
 # Build URLs from variables
-set kernel_url ${mirror}/${codename}/netboot/${os_arch}
-set ubuntu_iso_url ${mirror}/${codename}/${base_dir}-${version}-live-server-${os_arch}.iso
+set kernel_url ${mirror}/${version}/netboot/${os_arch}
+set ubuntu_iso_url ${mirror}/${version}/${base_dir}-${version}-live-server-${os_arch}.iso
 set autoinstall_url https://rampart-aios.github.io/autoinstall/deploy/${department}/${machine}
 
 # =============================================================================


### PR DESCRIPTION
**Issue:**
- `Unable to find a live file system on the network`
- That is caused by broken mirror URL https://releases.ubuntu.com/noble/
- Initially  that mirror points to ubuntu 24.04.2, but there's new update and now it points to ubuntu 24.04.3
- That's why I need to change it to https://old-releases.ubuntu.com/releases/ that list all older versions